### PR TITLE
Add structured content and MCP prompt sample functions

### DIFF
--- a/samples/FunctionsMcpTool/README.md
+++ b/samples/FunctionsMcpTool/README.md
@@ -19,6 +19,9 @@ This sample exposes three MCP tools:
 - [Azure Functions Core Tools v4](https://learn.microsoft.com/azure/azure-functions/functions-run-local) >= `4.0.7030`
 - [Docker](https://www.docker.com/) (for Azurite storage emulator)
 
+> [!NOTE]
+> This sample uses the **Preview** extension bundle (`Microsoft.Azure.Functions.ExtensionBundle.Preview`) because MCP prompt bindings (`mcpPromptTrigger`, `mcpPromptArgument`) are not yet available in the standard bundle. See `host.json` for the configuration.
+
 ## Getting Started
 
 ### 1. Start the Storage Emulator

--- a/samples/FunctionsMcpTool/README.md
+++ b/samples/FunctionsMcpTool/README.md
@@ -96,3 +96,16 @@ public String saveSnippet(
 **MCP Tool Properties** — Use `@McpToolProperty` to declare input parameters that the MCP client passes to your tool.
 
 **Azure Bindings** — Standard Azure Functions bindings (`@BlobInput`, `@BlobOutput`, `@StorageAccount`) work seamlessly with MCP triggers.
+
+## Troubleshooting
+
+### Image tools cause "Could not process image" errors in VS Code
+
+When using tools that return image content (`renderImage`, `getMultiContent`), you may see:
+
+```
+Request Failed: 400 {"message":"Could not process image"}
+```
+
+**What's happening:** The tools are returning content correctly — the function logic is working as expected. The image is returned and displayed successfully on the first response. However, on your *next* message, VS Code sends the full conversation history (including the image) back to the language model. The model endpoint may reject the image data in the history, causing the 400 error. This is a chat rendering/infrastructure issue, not a problem with the function app or MCP tool implementation.
+

--- a/samples/FunctionsMcpTool/host.json
+++ b/samples/FunctionsMcpTool/host.json
@@ -1,7 +1,7 @@
 {
   "version": "2.0",
   "extensionBundle": {
-    "id": "Microsoft.Azure.Functions.ExtensionBundle",
-    "version": "[4.*, 5.0.0)"
+    "id": "Microsoft.Azure.Functions.ExtensionBundle.Preview",
+    "version": "[4.41, 5.0.0)"
   }
 }

--- a/samples/FunctionsMcpTool/local.settings.json
+++ b/samples/FunctionsMcpTool/local.settings.json
@@ -2,6 +2,7 @@
   "IsEncrypted": false,
   "Values": {
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
-    "FUNCTIONS_WORKER_RUNTIME": "java"
+    "FUNCTIONS_WORKER_RUNTIME": "java",
+    "FUNCTIONS_EXTENSIONBUNDLE_SOURCE_URI": "https://cdn-staging.functions.azure.com/public"
   }
 }

--- a/samples/FunctionsMcpTool/local.settings.json
+++ b/samples/FunctionsMcpTool/local.settings.json
@@ -2,7 +2,6 @@
   "IsEncrypted": false,
   "Values": {
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
-    "FUNCTIONS_WORKER_RUNTIME": "java",
-    "FUNCTIONS_EXTENSIONBUNDLE_SOURCE_URI": "https://cdn-staging.functions.azure.com/public"
+    "FUNCTIONS_WORKER_RUNTIME": "java"
   }
 }

--- a/samples/FunctionsMcpTool/pom.xml
+++ b/samples/FunctionsMcpTool/pom.xml
@@ -12,8 +12,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>17</java.version>
-        <azure.functions.maven.plugin.version>1.40.0</azure.functions.maven.plugin.version>
-        <azure.functions.java.library.version>3.2.2</azure.functions.java.library.version>
+        <azure.functions.maven.plugin.version>1.42.0</azure.functions.maven.plugin.version>
+        <azure.functions.java.library.version>3.2.4</azure.functions.java.library.version>
         <functionAppName>HelloWorld-MCP</functionAppName>
     </properties>
 
@@ -22,6 +22,16 @@
             <groupId>com.microsoft.azure.functions</groupId>
             <artifactId>azure-functions-java-library</artifactId>
             <version>${azure.functions.java.library.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.microsoft.azure.functions</groupId>
+            <artifactId>azure-functions-java-mcp</artifactId>
+            <version>1.0.0</version>
+        </dependency>
+        <dependency>
+            <groupId>io.modelcontextprotocol.sdk</groupId>
+            <artifactId>mcp-json-jackson2</artifactId>
+            <version>1.1.0</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>

--- a/samples/FunctionsMcpTool/pom.xml
+++ b/samples/FunctionsMcpTool/pom.xml
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>com.microsoft.azure.functions</groupId>
             <artifactId>azure-functions-java-mcp</artifactId>
-            <version>1.0.0</version>
+            <version>1.0.1</version>
         </dependency>
         <dependency>
             <groupId>io.modelcontextprotocol.sdk</groupId>

--- a/samples/FunctionsMcpTool/pom.xml
+++ b/samples/FunctionsMcpTool/pom.xml
@@ -13,7 +13,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>17</java.version>
         <azure.functions.maven.plugin.version>1.42.0</azure.functions.maven.plugin.version>
-        <azure.functions.java.library.version>3.2.4</azure.functions.java.library.version>
+        <azure.functions.java.library.version>3.3.0</azure.functions.java.library.version>
         <functionAppName>HelloWorld-MCP</functionAppName>
     </properties>
 

--- a/samples/FunctionsMcpTool/src/main/java/com/function/PromptExamples.java
+++ b/samples/FunctionsMcpTool/src/main/java/com/function/PromptExamples.java
@@ -27,13 +27,11 @@ public class PromptExamples {
             String context,
             @McpPromptArgument(
                     name = "code",
-                    argumentName = "code",
                     description = "The code to review",
                     isRequired = true)
             String code,
             @McpPromptArgument(
                     name = "language",
-                    argumentName = "language",
                     description = "The programming language")
             String language,
             final ExecutionContext executionContext) {
@@ -60,7 +58,6 @@ public class PromptExamples {
             String context,
             @McpPromptArgument(
                     name = "text",
-                    argumentName = "text",
                     description = "The text to summarize",
                     isRequired = true)
             String text,

--- a/samples/FunctionsMcpTool/src/main/java/com/function/PromptExamples.java
+++ b/samples/FunctionsMcpTool/src/main/java/com/function/PromptExamples.java
@@ -1,0 +1,110 @@
+package com.function;
+
+import com.microsoft.azure.functions.ExecutionContext;
+import com.microsoft.azure.functions.annotation.FunctionName;
+import com.microsoft.azure.functions.annotation.McpPromptArgument;
+import com.microsoft.azure.functions.annotation.McpPromptTrigger;
+
+/**
+ * Demonstrates MCP Prompt functions that expose prompt templates to MCP clients.
+ * Clients discover prompts via prompts/list and invoke them via prompts/get.
+ * 
+ * Return a plain string (auto-wrapped into a single user message by the host)
+ * or a JSON-serialized GetPromptResult for multi-message / rich content responses.
+ */
+public class PromptExamples {
+
+    /**
+     * A code review prompt with multiple arguments (1 required, 1 optional).
+     * Uses McpPromptArgument annotations to define arguments in a strongly-typed way.
+     */
+    @FunctionName("CodeReviewPrompt")
+    public String codeReviewPrompt(
+            @McpPromptTrigger(
+                    name = "code_review",
+                    description = "Generates a code review prompt for the given code snippet",
+                    title = "Code Review")
+            String context,
+            @McpPromptArgument(
+                    name = "code",
+                    argumentName = "code",
+                    description = "The code to review",
+                    isRequired = true)
+            String code,
+            @McpPromptArgument(
+                    name = "language",
+                    argumentName = "language",
+                    description = "The programming language")
+            String language,
+            final ExecutionContext executionContext) {
+
+        executionContext.getLogger().info("Generating code review prompt");
+
+        String lang = (language != null && !language.isEmpty()) ? language : "unknown";
+        String snippet = (code != null && !code.isEmpty()) ? code : "// no code provided";
+
+        return "Please review the following " + lang + " code and suggest improvements:\n\n```"
+                + lang + "\n" + snippet + "\n```";
+    }
+
+    /**
+     * A summarize prompt with a single required argument and plain string return.
+     * The host auto-wraps the returned string into a PromptMessage with role "user".
+     */
+    @FunctionName("SummarizePrompt")
+    public String summarizePrompt(
+            @McpPromptTrigger(
+                    name = "summarize",
+                    description = "Summarizes the provided text",
+                    title = "Summarize Text")
+            String context,
+            @McpPromptArgument(
+                    name = "text",
+                    argumentName = "text",
+                    description = "The text to summarize",
+                    isRequired = true)
+            String text,
+            final ExecutionContext executionContext) {
+
+        executionContext.getLogger().info("Generating summarize prompt");
+
+        String input = (text != null && !text.isEmpty()) ? text : "No text provided";
+        return "Please provide a concise summary of the following text:\n\n" + input;
+    }
+
+    /**
+     * A prompt with no arguments. Tests the edge case of a prompt
+     * that takes no user input.
+     */
+    @FunctionName("NoArgsPrompt")
+    public String noArgsPrompt(
+            @McpPromptTrigger(
+                    name = "no_args_prompt",
+                    description = "A prompt that requires no arguments",
+                    title = "No Arguments Prompt")
+            String context,
+            final ExecutionContext executionContext) {
+
+        executionContext.getLogger().info("Generating no-args prompt");
+        return "This prompt requires no arguments. Please provide general guidance.";
+    }
+
+    /**
+     * A prompt with inline promptArguments JSON instead of McpPromptArgument annotations.
+     * This is the alternative approach — useful when arguments are static/known at compile time.
+     */
+    @FunctionName("InlineArgsPrompt")
+    public String inlineArgsPrompt(
+            @McpPromptTrigger(
+                    name = "inline_args_prompt",
+                    description = "A prompt with arguments defined via inline JSON",
+                    title = "Inline Arguments Prompt",
+                    promptArguments = "[{\"name\":\"topic\",\"description\":\"The topic to discuss\",\"required\":false},"
+                            + "{\"name\":\"style\",\"description\":\"The writing style\",\"required\":false}]")
+            String context,
+            final ExecutionContext executionContext) {
+
+        executionContext.getLogger().info("Generating inline-args prompt");
+        return "Please write about the specified topic in the requested style.";
+    }
+}

--- a/samples/FunctionsMcpTool/src/main/java/com/function/PromptExamples.java
+++ b/samples/FunctionsMcpTool/src/main/java/com/function/PromptExamples.java
@@ -85,23 +85,4 @@ public class PromptExamples {
         executionContext.getLogger().info("Generating no-args prompt");
         return "This prompt requires no arguments. Please provide general guidance.";
     }
-
-    /**
-     * A prompt with inline promptArguments JSON instead of McpPromptArgument annotations.
-     * This is the alternative approach — useful when arguments are static/known at compile time.
-     */
-    @FunctionName("InlineArgsPrompt")
-    public String inlineArgsPrompt(
-            @McpPromptTrigger(
-                    name = "inline_args_prompt",
-                    description = "A prompt with arguments defined via inline JSON",
-                    title = "Inline Arguments Prompt",
-                    promptArguments = "[{\"name\":\"topic\",\"description\":\"The topic to discuss\",\"required\":false},"
-                            + "{\"name\":\"style\",\"description\":\"The writing style\",\"required\":false}]")
-            String context,
-            final ExecutionContext executionContext) {
-
-        executionContext.getLogger().info("Generating inline-args prompt");
-        return "Please write about the specified topic in the requested style.";
-    }
 }

--- a/samples/FunctionsMcpTool/src/main/java/com/function/StructuredContentExamples.java
+++ b/samples/FunctionsMcpTool/src/main/java/com/function/StructuredContentExamples.java
@@ -1,0 +1,159 @@
+package com.function;
+
+import com.microsoft.azure.functions.ExecutionContext;
+import com.microsoft.azure.functions.annotation.FunctionName;
+import com.microsoft.azure.functions.annotation.McpToolProperty;
+import com.microsoft.azure.functions.annotation.McpToolTrigger;
+import com.microsoft.azure.functions.mcp.McpContent;
+import com.microsoft.azure.functions.mcp.McpToolResult;
+import io.modelcontextprotocol.spec.McpSchema.Content;
+import io.modelcontextprotocol.spec.McpSchema.ImageContent;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Demonstrates structured content support in Azure Functions MCP tools.
+ * 
+ * <p>These examples show three approaches for returning rich content from MCP tools:</p>
+ * <ol>
+ *   <li>{@link #getSnippetStructured} — {@code @McpContent}-annotated POJO (automatic text + structured content)</li>
+ *   <li>{@link #renderImage} — Single content block (ImageContentBlock)</li>
+ *   <li>{@link #getMultiContent} — Multiple content blocks (List of ContentBlock)</li>
+ * </ol>
+ * 
+ * <p>Note: These functions require the {@code azure-functions-java-mcp} dependency which provides
+ * the middleware that wraps return values into the MCP result envelope.</p>
+ */
+public class StructuredContentExamples {
+
+    // ========================================================================
+    // Example 1: @McpContent-annotated POJO
+    // The middleware automatically creates both text content (for backwards
+    // compatibility) and structured content (for clients that support it).
+    // ========================================================================
+
+    /**
+     * A snippet POJO decorated with @McpContent. When returned from an MCP tool function,
+     * this will be serialized as both text content (JSON text) and structured content
+     * (JSON object), enabling MCP clients to parse the result programmatically.
+     */
+    @McpContent
+    public static class SnippetResult {
+        private String name;
+        private String content;
+        private String language;
+
+        public SnippetResult() {
+        }
+
+        public SnippetResult(String name, String content, String language) {
+            this.name = name;
+            this.content = content;
+            this.language = language;
+        }
+
+        public String getName() { return name; }
+        public void setName(String name) { this.name = name; }
+        public String getContent() { return content; }
+        public void setContent(String content) { this.content = content; }
+        public String getLanguage() { return language; }
+        public void setLanguage(String language) { this.language = language; }
+    }
+
+    /**
+     * Returns a code snippet as structured content. The {@code @McpContent} annotation
+     * on {@code SnippetResult} tells the middleware to serialize the return value as both
+     * text content and structured content.
+     *
+     * <p>MCP clients that support structured content can parse the JSON object directly.
+     * Older clients will see the JSON as a text string.</p>
+     */
+    @FunctionName("GetSnippetStructured")
+    public SnippetResult getSnippetStructured(
+            @McpToolTrigger(
+                    name = "getSnippetStructured",
+                    description = "Gets a code snippet with structured content support.")
+            String context,
+            @McpToolProperty(
+                    name = "snippetName",
+                    propertyType = "string",
+                    description = "The name of the snippet to retrieve.",
+                    isRequired = true)
+            String snippetName,
+            final ExecutionContext executionContext) {
+
+        executionContext.getLogger().info("Getting structured snippet: " + snippetName);
+
+        return new SnippetResult(
+                snippetName,
+                "public class HelloWorld { public static void main(String[] args) { System.out.println(\"Hello!\"); } }",
+                "java"
+        );
+    }
+
+    // ========================================================================
+    // Example 2: Single content block (ImageContentBlock)
+    // For returning rich content types like images.
+    // ========================================================================
+
+    /**
+     * Returns an image as a single content block. The middleware wraps this
+     * in an MCP result envelope automatically.
+     */
+    @FunctionName("RenderImage")
+    public ImageContent renderImage(
+            @McpToolTrigger(
+                    name = "renderImage",
+                    description = "Returns a base64-encoded image.")
+            String context,
+            @McpToolProperty(
+                    name = "data",
+                    propertyType = "string",
+                    description = "Base64-encoded image data.",
+                    isRequired = true)
+            String data,
+            @McpToolProperty(
+                    name = "mimeType",
+                    propertyType = "string",
+                    description = "MIME type of the image (e.g., image/png).")
+            String mimeType,
+            final ExecutionContext executionContext) {
+
+        executionContext.getLogger().info("Rendering image with MIME type: " + mimeType);
+
+        return new ImageContent(null, data, mimeType != null ? mimeType : "image/png");
+    }
+
+    // ========================================================================
+    // Example 3: Multiple content blocks
+    // For returning a list of mixed content types in a single response.
+    // ========================================================================
+
+    /**
+     * Returns multiple content blocks — a text description followed by an image.
+     * The middleware wraps this as a multi-content result.
+     */
+    @FunctionName("GetMultiContent")
+    public List<Content> getMultiContent(
+            @McpToolTrigger(
+                    name = "getMultiContent",
+                    description = "Returns multiple content blocks including text and an image.")
+            String context,
+            @McpToolProperty(
+                    name = "imageData",
+                    propertyType = "string",
+                    description = "Base64-encoded image data.",
+                    isRequired = true)
+            String imageData,
+            final ExecutionContext executionContext) {
+
+        executionContext.getLogger().info("Generating multi-content response");
+
+        return Arrays.asList(
+                new TextContent("Here is the requested image:"),
+                new ImageContent(null, imageData, "image/png")
+        );
+    }
+}

--- a/samples/McpWeatherApp/pom.xml
+++ b/samples/McpWeatherApp/pom.xml
@@ -13,7 +13,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>17</java.version>
         <azure.functions.maven.plugin.version>1.42.0</azure.functions.maven.plugin.version>
-        <azure.functions.java.library.version>3.2.4</azure.functions.java.library.version>
+        <azure.functions.java.library.version>3.3.0</azure.functions.java.library.version>
         <functionAppName>McpWeatherApp</functionAppName>
     </properties>
 


### PR DESCRIPTION
## Summary

Adds sample functions demonstrating MCP structured content and prompt templates, and updates project dependencies.

## Structured content samples: StructuredContentExamples.java

Three functions demonstrating different rich content approaches:

1. **GetSnippetStructured** - Returns an @McpContent-annotated SnippetResult POJO. The middleware auto-serializes it as both text content (backward compat) and structured content (for clients that support it).
2. **RenderImage** - Returns an MCP SDK ImageContent directly. The middleware wraps it as a single image content block.
3. **GetMultiContent** - Returns a List of Content with a TextContent + ImageContent. The middleware wraps it as a multi-content result.

## Prompt samples: PromptExamples.java

Four functions demonstrating MCP prompt templates:

1. **CodeReviewPrompt** - Multi-argument prompt (1 required code arg, 1 optional language arg) using `@McpPromptArgument` annotations
2. **SummarizePrompt** - Single required argument prompt with plain string return
3. **NoArgsPrompt** - Prompt with no arguments (edge case)
4. **InlineArgsPrompt** - Prompt with arguments defined via inline JSON in `@McpPromptTrigger.promptArguments()`

## pom.xml changes

- Added azure-functions-java-mcp 1.0.0 dependency
- Added mcp-json-jackson2 1.1.0 for MCP SDK JSON serialization
- Updated azure-functions-java-library to 3.2.4
- Updated azure-functions-maven-plugin to 1.42.0

## local.settings.json

- Added staging CDN (`FUNCTIONS_EXTENSIONBUNDLE_SOURCE_URI`) — required until the extension bundle with `mcpPromptTrigger` support is published to the public CDN

## Related PRs
- [Azure/azure-functions-java-library#235](https://github.com/Azure/azure-functions-java-library/pull/235) — McpPromptTrigger and McpPromptArgument annotations
- [microsoft/azure-maven-plugins#2554](https://github.com/microsoft/azure-maven-plugins/pull/2554) — Maven plugin: registers bindings, generates function.json
- [Azure/azure-functions-java-additions#49](https://github.com/Azure/azure-functions-java-additions/pull/49) — azure-functions-java-mcp module
