### PR TITLE
Fix McpWeatherApp deployment: infra, prepackage hook, and file resolution

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -4,12 +4,18 @@
             "type": "promptString",
             "id": "functionapp-name",
             "description": "Azure Functions App Name"
+        },
+        {
+            "type": "promptString",
+            "id": "functionapp-key",
+            "description": "MCP Extension System Key",
+            "password": true
         }
     ],
     "servers": {
         "remote-mcp-function": {
             "type": "http",
-            "url": "https://${input:functionapp-name}.azurewebsites.net/runtime/webhooks/mcp"
+            "url": "https://${input:functionapp-name}.azurewebsites.net/runtime/webhooks/mcp?code=${input:functionapp-key}"
         },
         "local-mcp-function": {
             "type": "http",

--- a/azure.yaml
+++ b/azure.yaml
@@ -19,7 +19,7 @@ services:
       prepackage:
         windows:
           shell: pwsh
-          run: cd app; npm install; npm run build
+          run: cd app && npm install && npm run build
         posix:
           shell: sh
           run: cd app && npm install && npm run build

--- a/azure.yaml
+++ b/azure.yaml
@@ -15,3 +15,11 @@ services:
     project: ./samples/McpWeatherApp/
     language: java
     host: function
+    hooks:
+      prepackage:
+        windows:
+          shell: pwsh
+          run: cd app; npm install; npm run build
+        posix:
+          shell: sh
+          run: cd app && npm install && npm run build

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -97,9 +97,7 @@ module api './app/api.bicep' = {
     deploymentStorageContainerName: deploymentStorageContainerName
     identityId: apiUserAssignedIdentity.outputs.identityId
     identityClientId: apiUserAssignedIdentity.outputs.identityClientId
-    appSettings: {
-      FUNCTIONS_EXTENSIONBUNDLE_SOURCE_URI: 'https://cdn-staging.functions.azure.com/public'
-    }
+    appSettings: {}
     virtualNetworkSubnetId: !vnetEnabled ? '' : serviceVirtualNetwork.outputs.appSubnetID
   }
 }
@@ -121,9 +119,7 @@ module weather './app/api.bicep' = {
     identityId: apiUserAssignedIdentity.outputs.identityId
     identityClientId: apiUserAssignedIdentity.outputs.identityClientId
     serviceName: 'weather'
-    appSettings: {
-      FUNCTIONS_EXTENSIONBUNDLE_SOURCE_URI: 'https://cdn-staging.functions.azure.com/public'
-    }
+    appSettings: {}
     virtualNetworkSubnetId: !vnetEnabled ? '' : serviceVirtualNetwork.outputs.appSubnetID
   }
 }

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -16,6 +16,7 @@ param environmentName string
 param location string
 param vnetEnabled bool
 param apiServiceName string = ''
+param weatherServiceName string = ''
 param apiUserAssignedIdentityName string = ''
 param applicationInsightsName string = ''
 param appServicePlanName string = ''
@@ -30,6 +31,8 @@ var resourceToken = toLower(uniqueString(subscription().id, environmentName, loc
 var tags = { 'azd-env-name': environmentName }
 var functionAppName = !empty(apiServiceName) ? apiServiceName : '${abbrs.webSitesFunctions}api-${resourceToken}'
 var deploymentStorageContainerName = 'app-package-${take(functionAppName, 32)}-${take(toLower(uniqueString(functionAppName, resourceToken)), 7)}'
+var weatherFunctionAppName = !empty(weatherServiceName) ? weatherServiceName : '${abbrs.webSitesFunctions}weather-${resourceToken}'
+var weatherDeploymentStorageContainerName = 'app-package-${take(weatherFunctionAppName, 32)}-${take(toLower(uniqueString(weatherFunctionAppName, resourceToken)), 7)}'
 
 // Organize resources in a resource group
 resource rg 'Microsoft.Resources/resourceGroups@2021-04-01' = {
@@ -64,6 +67,21 @@ module appServicePlan './core/host/appserviceplan.bicep' = {
   }
 }
 
+// Separate plan for weather app (Flex Consumption allows only one site per plan)
+module weatherAppServicePlan './core/host/appserviceplan.bicep' = {
+  name: 'weatherappserviceplan'
+  scope: rg
+  params: {
+    name: '${abbrs.webServerFarms}weather-${resourceToken}'
+    location: location
+    tags: tags
+    sku: {
+      name: 'FC1'
+      tier: 'FlexConsumption'
+    }
+  }
+}
+
 module api './app/api.bicep' = {
   name: 'api'
   scope: rg
@@ -80,6 +98,31 @@ module api './app/api.bicep' = {
     identityId: apiUserAssignedIdentity.outputs.identityId
     identityClientId: apiUserAssignedIdentity.outputs.identityClientId
     appSettings: {
+      FUNCTIONS_EXTENSIONBUNDLE_SOURCE_URI: 'https://cdn-staging.functions.azure.com/public'
+    }
+    virtualNetworkSubnetId: !vnetEnabled ? '' : serviceVirtualNetwork.outputs.appSubnetID
+  }
+}
+
+// The weather app is a separate function app
+module weather './app/api.bicep' = {
+  name: 'weather'
+  scope: rg
+  params: {
+    name: weatherFunctionAppName
+    location: location
+    tags: tags
+    applicationInsightsName: monitoring.outputs.applicationInsightsName
+    appServicePlanId: weatherAppServicePlan.outputs.id
+    runtimeName: 'java'
+    runtimeVersion: '17'
+    storageAccountName: storage.outputs.name
+    deploymentStorageContainerName: weatherDeploymentStorageContainerName
+    identityId: apiUserAssignedIdentity.outputs.identityId
+    identityClientId: apiUserAssignedIdentity.outputs.identityClientId
+    serviceName: 'weather'
+    appSettings: {
+      FUNCTIONS_EXTENSIONBUNDLE_SOURCE_URI: 'https://cdn-staging.functions.azure.com/public'
     }
     virtualNetworkSubnetId: !vnetEnabled ? '' : serviceVirtualNetwork.outputs.appSubnetID
   }
@@ -93,7 +136,7 @@ module storage './core/storage/storage-account.bicep' = {
     name: !empty(storageAccountName) ? storageAccountName : '${abbrs.storageStorageAccounts}${resourceToken}'
     location: location
     tags: tags
-    containers: [{name: deploymentStorageContainerName}, {name: 'snippets'}]
+    containers: [{name: deploymentStorageContainerName}, {name: weatherDeploymentStorageContainerName}, {name: 'snippets'}]
     publicNetworkAccess: vnetEnabled ? 'Disabled' : 'Enabled'
     networkAcls: !vnetEnabled ? {} : {
       defaultAction: 'Deny'
@@ -179,5 +222,6 @@ module appInsightsRoleAssignmentApi './core/monitor/appinsights-access.bicep' = 
 output AZURE_LOCATION string = location
 output AZURE_TENANT_ID string = tenant().tenantId
 output SERVICE_API_NAME string = api.outputs.SERVICE_API_NAME
+output SERVICE_WEATHER_NAME string = weather.outputs.SERVICE_API_NAME
 output AZURE_FUNCTION_NAME string = api.outputs.SERVICE_API_NAME
 output AZURE_RESOURCE_GROUP string = rg.name

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -30,9 +30,9 @@ var abbrs = loadJsonContent('./abbreviations.json')
 var resourceToken = toLower(uniqueString(subscription().id, environmentName, location))
 var tags = { 'azd-env-name': environmentName }
 var functionAppName = !empty(apiServiceName) ? apiServiceName : '${abbrs.webSitesFunctions}api-${resourceToken}'
-var deploymentStorageContainerName = 'app-package-${take(functionAppName, 32)}-${take(toLower(uniqueString(functionAppName, resourceToken)), 7)}'
+var deploymentStorageContainerName = 'app-package-${take(toLower(functionAppName), 32)}-${take(toLower(uniqueString(functionAppName, resourceToken)), 7)}'
 var weatherFunctionAppName = !empty(weatherServiceName) ? weatherServiceName : '${abbrs.webSitesFunctions}weather-${resourceToken}'
-var weatherDeploymentStorageContainerName = 'app-package-${take(weatherFunctionAppName, 32)}-${take(toLower(uniqueString(weatherFunctionAppName, resourceToken)), 7)}'
+var weatherDeploymentStorageContainerName = 'app-package-${take(toLower(weatherFunctionAppName), 32)}-${take(toLower(uniqueString(weatherFunctionAppName, resourceToken)), 7)}'
 
 // Organize resources in a resource group
 resource rg 'Microsoft.Resources/resourceGroups@2021-04-01' = {

--- a/samples/FunctionsMcpTool/host.json
+++ b/samples/FunctionsMcpTool/host.json
@@ -2,6 +2,6 @@
   "version": "2.0",
   "extensionBundle": {
     "id": "Microsoft.Azure.Functions.ExtensionBundle",
-    "version": "[4.29.0, 5.0.0)"
+    "version": "[4.*, 5.0.0)"
   }
 }

--- a/samples/McpWeatherApp/README.md
+++ b/samples/McpWeatherApp/README.md
@@ -20,7 +20,7 @@ Azure Functions makes it easy to build both.
 - [JDK 17](https://learn.microsoft.com/java/openjdk/download) (or newer)
 - [Apache Maven](https://maven.apache.org/download.cgi)
 - [Node.js](https://nodejs.org/) (for building the UI)
-- [Azure Functions Core Tools v4](https://learn.microsoft.com/azure/azure-functions/functions-run-local)
+- [Azure Functions Core Tools v4.9](https://learn.microsoft.com/azure/azure-functions/functions-run-local)
 - An MCP-compatible host (VS Code with GitHub Copilot, Claude Desktop, etc.)
 
 ## Getting Started

--- a/samples/McpWeatherApp/README.md
+++ b/samples/McpWeatherApp/README.md
@@ -20,7 +20,7 @@ Azure Functions makes it easy to build both.
 - [JDK 17](https://learn.microsoft.com/java/openjdk/download) (or newer)
 - [Apache Maven](https://maven.apache.org/download.cgi)
 - [Node.js](https://nodejs.org/) (for building the UI)
-- [Azure Functions Core Tools v4.9](https://learn.microsoft.com/azure/azure-functions/functions-run-local)
+- [Azure Functions Core Tools v4](https://learn.microsoft.com/azure/azure-functions/functions-run-local)
 - An MCP-compatible host (VS Code with GitHub Copilot, Claude Desktop, etc.)
 
 ## Getting Started

--- a/samples/McpWeatherApp/host.json
+++ b/samples/McpWeatherApp/host.json
@@ -18,6 +18,6 @@
   },
   "extensionBundle": {
     "id": "Microsoft.Azure.Functions.ExtensionBundle",
-    "version": "[4.32.0, 4.33.0)"
+    "version": "[4.*, 5.0.0)"
   }
 }

--- a/samples/McpWeatherApp/local.settings.json
+++ b/samples/McpWeatherApp/local.settings.json
@@ -1,0 +1,7 @@
+{
+    "IsEncrypted": false,
+    "Values": {
+        "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+        "FUNCTIONS_WORKER_RUNTIME": "java"
+    }
+}

--- a/samples/McpWeatherApp/pom.xml
+++ b/samples/McpWeatherApp/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>17</java.version>
-        <azure.functions.maven.plugin.version>1.41.0</azure.functions.maven.plugin.version>
+        <azure.functions.maven.plugin.version>1.42.0</azure.functions.maven.plugin.version>
         <azure.functions.java.library.version>3.2.4</azure.functions.java.library.version>
         <functionAppName>McpWeatherApp</functionAppName>
     </properties>

--- a/samples/McpWeatherApp/src/main/java/com/function/weather/WeatherFunction.java
+++ b/samples/McpWeatherApp/src/main/java/com/function/weather/WeatherFunction.java
@@ -67,7 +67,19 @@ public class WeatherFunction {
 
         executionContext.getLogger().info("GetWeatherWidget: serving weather widget UI");
 
-        // Try loading from the filesystem (app/dist/index.html placed next to the function)
+        // Try loading relative to the jar location (required on Azure where CWD differs)
+        try {
+            java.io.File jarDir = new java.io.File(
+                    WeatherFunction.class.getProtectionDomain().getCodeSource().getLocation().toURI()).getParentFile();
+            java.io.File jarRelative = new java.io.File(jarDir, "app/dist/index.html");
+            if (jarRelative.exists()) {
+                return java.nio.file.Files.readString(jarRelative.toPath(), StandardCharsets.UTF_8);
+            }
+        } catch (Exception e) {
+            executionContext.getLogger().log(Level.WARNING, "Failed to resolve jar-relative path", e);
+        }
+
+        // Fallback: try CWD-relative path (works for local dev)
         java.io.File file = new java.io.File("app/dist/index.html");
         if (file.exists()) {
             try {

--- a/samples/McpWeatherApp/src/main/java/com/function/weather/WeatherFunction.java
+++ b/samples/McpWeatherApp/src/main/java/com/function/weather/WeatherFunction.java
@@ -68,15 +68,20 @@ public class WeatherFunction {
         executionContext.getLogger().info("GetWeatherWidget: serving weather widget UI");
 
         // Try loading relative to the jar location (required on Azure where CWD differs)
+        java.io.File jarRelative = null;
         try {
             java.io.File jarDir = new java.io.File(
                     WeatherFunction.class.getProtectionDomain().getCodeSource().getLocation().toURI()).getParentFile();
-            java.io.File jarRelative = new java.io.File(jarDir, "app/dist/index.html");
-            if (jarRelative.exists()) {
-                return java.nio.file.Files.readString(jarRelative.toPath(), StandardCharsets.UTF_8);
-            }
+            jarRelative = new java.io.File(jarDir, "app/dist/index.html");
         } catch (Exception e) {
             executionContext.getLogger().log(Level.WARNING, "Failed to resolve jar-relative path", e);
+        }
+        if (jarRelative != null && jarRelative.exists()) {
+            try {
+                return java.nio.file.Files.readString(jarRelative.toPath(), StandardCharsets.UTF_8);
+            } catch (IOException e) {
+                executionContext.getLogger().log(Level.WARNING, "Failed to read UI from jar-relative file", e);
+            }
         }
 
         // Fallback: try CWD-relative path (works for local dev)


### PR DESCRIPTION
# Fix McpWeatherApp deployment: infra, prepackage hook, and file resolution

This PR fixes the McpWeatherApp sample so it works both locally and when deployed to Azure via `azd up`.

## Problems Fixed

1. **No infrastructure for weather service** – The Bicep only provisioned one function app (`api`), but `azure.yaml` defines a `weather` service. Added a separate Flex Consumption plan and function app for the weather service (Flex Consumption allows only one site per plan).

2. **UI not built during deployment** – `azd deploy` runs `mvn package` but the Vite UI (`app/dist/index.html`) was never built, so the resource endpoint returned "Widget not found". Added a `prepackage` hook in `azure.yaml` that runs `npm install` and `npm run build` before Maven packaging.

3. **File not found on Azure** – The widget code used a CWD-relative file path. On Azure Flex Consumption, the CWD differs from the function app root, so the file was never found. Fixed to resolve the path relative to the jar location.

4. **Remote MCP auth** – Updated `mcp.json` to accept a system key for authenticated remote MCP connections.

## Testing

- **Local:** All MCP endpoints verified (initialize, tools/list, tools/call, resources/list, resources/read)
- **Remote (Azure):** All endpoints verified after deployment via `azd deploy`
- **VS Code Copilot:** Both local and remote MCP servers connected and invoked successfully