### PR TITLE
Fix McpWeatherApp: bump azure-functions-maven-plugin to 1.42.0

### DIFF
--- a/samples/McpWeatherApp/README.md
+++ b/samples/McpWeatherApp/README.md
@@ -38,7 +38,25 @@ cd ..
 
 This creates a bundled `app/dist/index.html` file that the function serves.
 
-### 2. Build and Run the Function App
+### 2. Add a `local.settings.json`
+
+The MCP tool trigger is not an HTTP trigger, so the Functions host requires an `AzureWebJobsStorage` connection. Create `local.settings.json` in the project root (next to `host.json`):
+
+```json
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "FUNCTIONS_WORKER_RUNTIME": "java"
+  }
+}
+```
+
+`UseDevelopmentStorage=true` points at [Azurite](https://learn.microsoft.com/azure/storage/common/storage-use-azurite); start it in another terminal (`azurite`) or via the VS Code Azurite extension. Alternatively, paste a real Azure Storage connection string.
+
+> The maven plugin copies `local.settings.json` into `target/azure-functions/<appname>/` during `package`. If you add or change the file after building, re-run `mvn clean package` so the staged copy is refreshed.
+
+### 3. Build and Run the Function App
 
 ```bash
 mvn clean package
@@ -47,11 +65,11 @@ mvn azure-functions:run
 
 The MCP server will be available at `http://localhost:7071/runtime/webhooks/mcp`.
 
-### 3. Connect from VS Code
+### 4. Connect from VS Code
 
 Open **.vscode/mcp.json** at the repo root. Find the server called *local-mcp-function* and click **Start** above the name.
 
-### 4. Prompt the Agent
+### 5. Prompt the Agent
 
 Ask Copilot: "What's the weather in Seattle?"
 

--- a/samples/McpWeatherApp/pom.xml
+++ b/samples/McpWeatherApp/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>17</java.version>
-        <azure.functions.maven.plugin.version>1.41.0</azure.functions.maven.plugin.version>
+        <azure.functions.maven.plugin.version>1.42.0</azure.functions.maven.plugin.version>
         <azure.functions.java.library.version>3.2.4</azure.functions.java.library.version>
         <functionAppName>McpWeatherApp</functionAppName>
     </properties>


### PR DESCRIPTION
## Problem

Running `mvn azure-functions:run` for `samples/McpWeatherApp` fails at startup:

```
The 'GetWeatherWidget' function is in error: At least one binding must be declared.
```

The generated `target/azure-functions/McpWeatherApp/GetWeatherWidget/function.json` has no `bindings` array.

## Root cause

`azure-functions-maven-plugin` 1.41.0 pulls in `azure-toolkit-appservice-lib` 0.55.0, whose `BindingEnum` knows about `McpToolTrigger` and `McpToolProperty` but **not** `McpResourceTrigger`. The plugin silently emits a `function.json` with no bindings, which the Functions host then rejects.

Plugin 1.42.0 (released 2026-05-18) depends on `azure-toolkit-appservice-lib` 0.56.0, which adds `McpResourceTrigger`, `McpMetadata`, `McpPromptTrigger`, and `McpPromptArgument` to the enum. After the bump, the binding is generated correctly and the host starts cleanly.

## Changes

- `samples/McpWeatherApp/pom.xml`: bump `azure.functions.maven.plugin.version` from `1.41.0` to `1.42.0`.
- `samples/McpWeatherApp/README.md`: add an "Add a `local.settings.json`" step. The MCP tool trigger is not HTTP-based, so the host needs `AzureWebJobsStorage` like other non-HTTP triggers. Also notes that the maven plugin stages `local.settings.json` into `target/` at `package` time, so adding it after building requires a re-package.

## Validation

```
mvn -f samples/McpWeatherApp/pom.xml clean package
cat samples/McpWeatherApp/target/azure-functions/McpWeatherApp/GetWeatherWidget/function.json
```

Now shows a populated `bindings` array with `mcpResourceTrigger`.