### PR TITLE
Add defaultFunctionAppPath to fix VS Code F5 startup

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,6 @@
     "azureFunctions.projectRuntime": "~4",
     "debug.internalConsoleOptions": "neverOpen",
     "azureFunctions.preDeployTask": "package (functions)",
-    "java.configuration.updateBuildConfiguration": "interactive"
+    "java.configuration.updateBuildConfiguration": "interactive",
+    "azureFunctions.defaultFunctionAppPath": "."
 }


### PR DESCRIPTION
Adds `azureFunctions.defaultFunctionAppPath` to `.vscode/settings.json` so the Azure Functions extension correctly identifies the function app project without prompting users about multiple detected projects.